### PR TITLE
Add extension to use render mathematical formulas

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => { 
+  MathJax.startup.output.clearCache()
+  MathJax.typesetClear()
+  MathJax.texReset()
+  MathJax.typesetPromise()
+})

--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,5 @@ channels:
   - conda-forge
 dependencies:
   - mkdocs
+  - pymdown-extensions
 prefix: /home/gjb/mambaforge/envs/mkdocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,3 +40,10 @@ theme:
     - python
     - r
     - bash
+markdown_extensions:
+  - pymdownx.arithmatex:
+      generic: true
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to render mathematical formulas in the documentation by adding the pymdownx.arithmatex extension and configuring MathJax. It also updates the environment configuration to include the necessary dependencies.

- **New Features**:
    - Added support for rendering mathematical formulas using the pymdownx.arithmatex extension.
- **Enhancements**:
    - Included MathJax configuration to support inline and display math rendering.
- **Build**:
    - Updated environment.yml to include pymdown-extensions dependency.

<!-- Generated by sourcery-ai[bot]: end summary -->