### PR TITLE
Fix URL for gprof

### DIFF
--- a/docs/tools/C-plus-plus.md
+++ b/docs/tools/C-plus-plus.md
@@ -34,7 +34,7 @@
 
 ## Profiling
 
-  * [gprof](https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.htmlhttps://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html)
+  * [gprof](https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html)
     is a free profiler.
   * [Intel
     VTune](https://software.intel.com/content/www/us/en/develop/tools/vtune-profiler.html)

--- a/docs/tools/C.md
+++ b/docs/tools/C.md
@@ -34,7 +34,7 @@
 
 ## Profiling
 
-  * [gprof](https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.htmlhttps://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html)
+  * [gprof](https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html)
     is a free profiler.
   * [Intel
     VTune](https://software.intel.com/content/www/us/en/develop/tools/vtune-profiler.html)

--- a/docs/tools/Fortran.md
+++ b/docs/tools/Fortran.md
@@ -9,7 +9,7 @@
 
 ## Profiling
 
-  * [gprof](https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.htmlhttps://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html)
+  * [gprof](https://ftp.gnu.org/old-gnu/Manuals/gprof-2.9.1/html_mono/gprof.html)
     is a free profiler.
   * [Intel
     VTune](https://software.intel.com/content/www/us/en/develop/tools/vtune-profiler.html)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the incorrect URL for gprof in the documentation files for C++, C, and Fortran tools.

- **Bug Fixes**:
    - Corrected the URL for gprof in the documentation for C++, C, and Fortran tools.

<!-- Generated by sourcery-ai[bot]: end summary -->